### PR TITLE
LIME-365: The loading icon is not centered on the Goals page

### DIFF
--- a/frontend/src/bundles/common/components/base-layout/styles.module.css
+++ b/frontend/src/bundles/common/components/base-layout/styles.module.css
@@ -7,7 +7,7 @@
 }
 
 .content-container {
-    @apply bg-secondary max-h-90 min-w-[320px] overflow-y-auto overflow-x-hidden p-8;
+    @apply bg-secondary max-h-90 relative min-w-[320px] overflow-y-auto overflow-x-hidden p-8;
 
     grid-area: main;
 }

--- a/frontend/src/bundles/goals/pages/goals.tsx
+++ b/frontend/src/bundles/goals/pages/goals.tsx
@@ -109,7 +109,7 @@ const Goals: React.FC = () => {
     return (
         <main className="bg-secondary flex w-full flex-col gap-8 md:justify-between lg:flex-row lg:justify-normal">
             {isLoading ? (
-                <Loader />
+                <Loader isOverflow />
             ) : (
                 <>
                     <div className="flex flex-col gap-8 ">


### PR DESCRIPTION
The loading icon is centred on the Goals page

https://www.loom.com/share/ab1db2eeb21e4fb1bab9c9f2711b7e04