### PR TITLE
LIME-373: Add label for distance or duration on list items of Goals section on Goals page

### DIFF
--- a/frontend/src/bundles/common/helpers/convert-meters-to-kilometers/convert-meters-to-kilometers.helper.ts
+++ b/frontend/src/bundles/common/helpers/convert-meters-to-kilometers/convert-meters-to-kilometers.helper.ts
@@ -1,0 +1,10 @@
+const METERS_TO_KILOMETERS = 1 / 1000;
+
+const convertMetersToKilometers = (value: number | null): number | null => {
+    if (!value) {
+        return null;
+    }
+    return value * METERS_TO_KILOMETERS;
+};
+
+export { convertMetersToKilometers };

--- a/frontend/src/bundles/common/helpers/helpers.ts
+++ b/frontend/src/bundles/common/helpers/helpers.ts
@@ -2,6 +2,7 @@ export { applyThemeClassname } from './apply-theme-classname/apply-theme-classna
 export { capitalizeFirstLetter } from './capitalize-first-letter/capitalize-first-letter.helper.js';
 export { convertHeightToCentimeters } from './convert-height/convert-height-to-cm.js';
 export { convertHeightToMillimeters } from './convert-height/convert-height-to-mm.js';
+export { convertMetersToKilometers } from './convert-meters-to-kilometers/convert-meters-to-kilometers.helper.js';
 export { convertSecondsToHMS } from './convert-seconds-to-hms/convert-seconds-to-hms.helper.js';
 export { convertToMeters } from './convert-to-meters/convert-to-meters.helper.js';
 export { convertWeightToGrams } from './convert-weight/convert-weight-to-grams.js';

--- a/frontend/src/bundles/goals/components/goal-card/goal-card.tsx
+++ b/frontend/src/bundles/goals/components/goal-card/goal-card.tsx
@@ -1,20 +1,27 @@
 import { ActivityIcon } from '~/bundles/common/components/components.js';
 import { ComponentSize } from '~/bundles/common/enums/component-size.enum.js';
-import { capitalizeFirstLetter } from '~/bundles/common/helpers/helpers.js';
+import {
+    capitalizeFirstLetter,
+    convertMetersToKilometers,
+} from '~/bundles/common/helpers/helpers.js';
 import { type ValueOf } from '~/bundles/common/types/types.js';
 import { type ActivityType } from '~/bundles/goals/enums/enums.js';
 import { CircleProgress } from '~/bundles/overview/components/components.js';
 
-import { type FrequencyType } from '../../enums/enums.js';
+import { FrequencyType } from '../../enums/enums.js';
 
 type Properties = {
     activityType: ValueOf<typeof ActivityType>;
     frequency: number;
     progress: number;
     frequencyType: ValueOf<typeof FrequencyType>;
+    distance?: number | null;
+    duration?: number | null;
 };
 
 const PLURAL = 's';
+const DAY_PREPOSITION = 'a';
+const WEEK_PREPOSITION = 'per';
 const MAXIMUM_PROGRESS = 100;
 
 const GoalCard: React.FC<Properties> = ({
@@ -22,9 +29,11 @@ const GoalCard: React.FC<Properties> = ({
     frequency,
     progress,
     frequencyType,
+    distance = null,
+    duration = null,
 }): JSX.Element => {
     return (
-        <div className="bg-secondary flex h-[7.5rem] w-full items-center justify-between rounded-xl p-3 pl-5 lg:p-5 lg:pl-8 xl:w-96">
+        <div className="bg-primary flex h-[7.5rem] w-full items-center justify-between rounded-xl p-3 pl-5 lg:p-5 lg:pl-8 xl:w-96">
             <div className="flex items-center gap-4">
                 <ActivityIcon
                     activityType={activityType}
@@ -32,11 +41,17 @@ const GoalCard: React.FC<Properties> = ({
                 />
                 <div className="flex flex-col">
                     <p className="text-primary text-sm font-extrabold leading-5 md:text-base">
-                        {capitalizeFirstLetter(activityType)}
+                        {capitalizeFirstLetter(activityType)}{' '}
+                        {distance
+                            ? `${convertMetersToKilometers(distance)} km`
+                            : `${duration} min`}
                     </p>
                     <p className="text-lm-grey-200 text-xs font-normal leading-3">
-                        {frequency} {frequencyType}
-                        {frequency > 1 && PLURAL}
+                        {frequency} time{frequency > 1 && PLURAL}{' '}
+                        {frequencyType === FrequencyType.DAY
+                            ? DAY_PREPOSITION
+                            : WEEK_PREPOSITION}{' '}
+                        {frequencyType}
                     </p>
                 </div>
             </div>

--- a/frontend/src/bundles/goals/components/goal-card/goal-card.tsx
+++ b/frontend/src/bundles/goals/components/goal-card/goal-card.tsx
@@ -33,7 +33,7 @@ const GoalCard: React.FC<Properties> = ({
     duration = null,
 }): JSX.Element => {
     return (
-        <div className="bg-primary flex h-[7.5rem] w-full items-center justify-between rounded-xl p-3 pl-5 lg:p-5 lg:pl-8 xl:w-96">
+        <div className="bg-secondary flex h-[7.5rem] w-full items-center justify-between rounded-xl p-3 pl-5 lg:p-5 lg:pl-8 xl:w-96">
             <div className="flex items-center gap-4">
                 <ActivityIcon
                     activityType={activityType}

--- a/frontend/src/bundles/goals/pages/goals.tsx
+++ b/frontend/src/bundles/goals/pages/goals.tsx
@@ -115,8 +115,14 @@ const Goals: React.FC = () => {
                     <div className="flex flex-col gap-8 ">
                         <section className="md:w-full lg:w-[37rem] xl:w-[49rem]">
                             <GoalWidget
-                                value={lastGoal?.progress as number}
-                                target={lastGoal?.progress as number}
+                                value={
+                                    (lastGoal?.distance as number) ||
+                                    (lastGoal?.duration as number)
+                                }
+                                target={
+                                    (lastGoal?.distance as number) ||
+                                    (lastGoal?.duration as number)
+                                }
                                 title={
                                     lastGoal
                                         ? GOALS_MESSAGES.GOAL_COMPLETED
@@ -133,6 +139,7 @@ const Goals: React.FC = () => {
                                         : GoalTypes.STANDART
                                 }
                                 hasAchievement={Boolean(lastGoal)}
+                                hasDistance={Boolean(lastGoal?.distance)}
                             />
                         </section>
                         <section>
@@ -154,6 +161,8 @@ const Goals: React.FC = () => {
                                             frequency,
                                             frequencyType,
                                             progress,
+                                            distance,
+                                            duration,
                                         }) => (
                                             <GoalCard
                                                 key={id}
@@ -161,6 +170,8 @@ const Goals: React.FC = () => {
                                                 frequency={frequency}
                                                 frequencyType={frequencyType}
                                                 progress={progress}
+                                                distance={distance}
+                                                duration={duration}
                                             />
                                         ),
                                     )}

--- a/frontend/src/bundles/goals/store/slice.ts
+++ b/frontend/src/bundles/goals/store/slice.ts
@@ -36,7 +36,7 @@ const { reducer, actions, name } = createSlice({
         });
         builder.addCase(createGoal.fulfilled, (state, action) => {
             state.dataStatus = DataStatus.FULFILLED;
-            state.goals.unshift(action.payload);
+            state.goals.push(action.payload);
         });
         builder.addCase(createGoal.rejected, (state) => {
             state.dataStatus = DataStatus.REJECTED;

--- a/frontend/src/bundles/overview/components/circle-progress/circle-progress.tsx
+++ b/frontend/src/bundles/overview/components/circle-progress/circle-progress.tsx
@@ -1,5 +1,8 @@
 import { ComponentSize } from '~/bundles/common/enums/component-size.enum.js';
-import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
+import {
+    convertMetersToKilometers,
+    getValidClassNames,
+} from '~/bundles/common/helpers/helpers.js';
 import { type ValueOf } from '~/bundles/common/types/types.js';
 import { DOUBLE_VALUE } from '~/bundles/overview/components/circle-progress/constants/constants.js';
 import {
@@ -16,6 +19,7 @@ type CircularProgressProperties = {
     size?: CircleSizes;
     goalType?: ValueOf<typeof GoalTypes>;
     color?: ValueOf<typeof CircularProgressColors>;
+    hasDistance?: boolean;
 };
 
 const classes = {
@@ -32,6 +36,7 @@ const CircleProgress = ({
     size = ComponentSize.MEDIUM,
     color = CircularProgressColors.primary,
     goalType = GoalTypes.STANDART,
+    hasDistance = false,
 }: CircularProgressProperties): JSX.Element => {
     const { radius, stroke } = CircularProgressSizes[size];
     const { fontSize, fontFamily, fontColor } =
@@ -115,9 +120,13 @@ const CircleProgress = ({
                                 fontColor,
                             )}
                         >
-                            {value}
+                            {hasDistance
+                                ? convertMetersToKilometers(value)
+                                : value}
                         </p>
-                        <p className="inline-flex font-normal">km</p>
+                        <p className="inline-flex font-normal">
+                            {hasDistance ? 'km' : 'min'}
+                        </p>
                     </>
                 )}
             </div>

--- a/frontend/src/bundles/overview/components/goal-widget/goal-widget.tsx
+++ b/frontend/src/bundles/overview/components/goal-widget/goal-widget.tsx
@@ -16,6 +16,7 @@ type WidgetProperties = {
     subTitle?: string;
     className?: string;
     hasAchievement?: boolean;
+    hasDistance?: boolean;
 };
 
 const GoalWidget = ({
@@ -26,6 +27,7 @@ const GoalWidget = ({
     subTitle = '',
     hasAchievement = true,
     className = '',
+    hasDistance = false,
 }: WidgetProperties): JSX.Element => {
     const rightTitle =
         goalType === GoalTypes.OVERVIEW
@@ -62,6 +64,7 @@ const GoalWidget = ({
                             value={value}
                             target={target}
                             goalType={goalType}
+                            hasDistance={hasDistance}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Add label for distance or duration on list items of Goals section on Goals page
![Screenshot_18](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/105019200/0de6de99-2f97-4620-b090-c63e4423fcb2)
![Screenshot_19](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/105019200/93a8fe3e-fcdd-4b12-ae1b-d6d9243d5444)
