### PR TITLE
LIME-463: BUG: Workout card for walking activity displays 0 km when distance > 0, steps = 0, provider null

### DIFF
--- a/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
+++ b/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
@@ -24,7 +24,7 @@ const WorkoutStats: React.FC<Properties> = ({ workout }): JSX.Element => {
     } = workout;
 
     const workoutDistance =
-        steps && steps != 0 ? steps : metersToKilometers(distance);
+        steps && steps !== 0 ? steps : metersToKilometers(distance);
     const distanceUnit = steps
         ? capitalizeFirstLetter(WorkoutUnit.STEPS)
         : WorkoutUnit.KILOMETERS;

--- a/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
+++ b/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
@@ -23,7 +23,7 @@ const WorkoutStats: React.FC<Properties> = ({ workout }): JSX.Element => {
         workoutEndedAt,
     } = workout;
 
-    const workoutDistance = steps ?? metersToKilometers(distance);
+    const workoutDistance = steps && steps != 0 ? steps :  metersToKilometers(distance);
     const distanceUnit = steps
         ? capitalizeFirstLetter(WorkoutUnit.STEPS)
         : WorkoutUnit.KILOMETERS;

--- a/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
+++ b/frontend/src/bundles/workouts/components/workout-stats/workout-stats.tsx
@@ -23,7 +23,8 @@ const WorkoutStats: React.FC<Properties> = ({ workout }): JSX.Element => {
         workoutEndedAt,
     } = workout;
 
-    const workoutDistance = steps && steps != 0 ? steps :  metersToKilometers(distance);
+    const workoutDistance =
+        steps && steps != 0 ? steps : metersToKilometers(distance);
     const distanceUnit = steps
         ? capitalizeFirstLetter(WorkoutUnit.STEPS)
         : WorkoutUnit.KILOMETERS;


### PR DESCRIPTION
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/53876827/a1edd7c5-d810-4c38-9660-414e7635e86c)
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/53876827/5d872d41-a1c7-43e3-9eb9-80e412f95cab)
