### PR TITLE
LIME-492: Remove Help button from sidebar

### DIFF
--- a/frontend/src/bundles/common/components/sidebar/sidebar.tsx
+++ b/frontend/src/bundles/common/components/sidebar/sidebar.tsx
@@ -4,7 +4,6 @@ import {
 } from '@heroicons/react/16/solid';
 import {
     ArrowLeftStartOnRectangleIcon as LogoutIcon,
-    QuestionMarkCircleIcon as HelpIcon,
     Squares2X2Icon as OverviewIcon,
 } from '@heroicons/react/24/outline';
 
@@ -117,13 +116,6 @@ const Sidebar: React.FC<Properties> = ({ isOpen = true }): JSX.Element => {
 
             <div className="flex h-1/4 w-full">
                 <div className="flex w-full flex-col justify-end gap-3">
-                    <SidebarNav
-                        icon={<HelpIcon />}
-                        text="Help"
-                        to={AppRoute.HELP}
-                        isActive={activeRoute === AppRoute.HELP}
-                    />
-
                     <div className="text-lm-grey-200 flex items-center justify-center">
                         <Button
                             type="button"


### PR DESCRIPTION
Remove Help button from sidebar
![Screenshot_20](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/105019200/96c44b34-f523-4ac5-b4a3-ba25a45943d2)
