### PR TITLE
LIME-493: Fixed height of ad banner

### DIFF
--- a/frontend/src/bundles/overview/pages/overview.tsx
+++ b/frontend/src/bundles/overview/pages/overview.tsx
@@ -105,7 +105,7 @@ const Overview: React.FC = () => {
                     </li>
                 </ul>
                 {!isSubscribed && (
-                    <GoogleAds className="mb-6 hidden h-44 xl:flex" />
+                    <GoogleAds className="mb-6 hidden h-48 xl:flex" />
                 )}
                 <ChartGoalProgress />
                 <div className="mt-5">Achievements</div>


### PR DESCRIPTION
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/74872088/731888ec-e1e4-479f-a049-0add56a04dc0)
