### PR TITLE
LIME-524: "No goals yet" fix

### DIFF
--- a/frontend/src/bundles/goals/pages/goals.tsx
+++ b/frontend/src/bundles/goals/pages/goals.tsx
@@ -152,8 +152,7 @@ const Goals: React.FC = () => {
                                 Goals
                             </h2>
                             <div className="mb-4 flex flex-col gap-4 lg:flex-row lg:flex-wrap">
-                                {(goals.length === ZERO_VALUE &&
-                                    unfulfilledGoals.length === ZERO_VALUE) || (
+                                {unfulfilledGoals.length === ZERO_VALUE && (
                                     <p className="text-primary mb-5 w-full text-xl font-extrabold">
                                         No goals yet
                                     </p>


### PR DESCRIPTION
Fixed "No goals yet" text is displayed when user has goals
![Screenshot_22](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/105019200/66875c4b-11a3-4938-8faf-6901e67bfad8)
