### PR TITLE
LIME-525: Fix colors of icons on Activity widgets

### DIFF
--- a/frontend/src/bundles/profile/pages/public-profile-page/public-profile-page.tsx
+++ b/frontend/src/bundles/profile/pages/public-profile-page/public-profile-page.tsx
@@ -137,7 +137,7 @@ const PublicProfile: React.FC = () => {
                                 <ActivityWidget
                                     label="Total distance"
                                     value={`${metersToKilometers(totalDistance)} km`}
-                                    color={ActivityWidgetColor.MAGENTA}
+                                    color={ActivityWidgetColor.PURPLE}
                                     icon={<Icon name={IconName.stepsIcon} />}
                                 />
                             </li>
@@ -153,7 +153,7 @@ const PublicProfile: React.FC = () => {
                                 <ActivityWidget
                                     label="Total calories"
                                     value={`${totalCalories} kcl`}
-                                    color={ActivityWidgetColor.PURPLE}
+                                    color={ActivityWidgetColor.MAGENTA}
                                     icon={<Icon name={IconName.caloriesIcon} />}
                                 />
                             </li>


### PR DESCRIPTION
Fix colors of icons on Activity widgets

![Screenshot_23](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-lime/assets/105019200/fb776cdb-405a-4710-9928-42bcbc691df1)
